### PR TITLE
Adding in .gitattributes file for syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
The solidity contracts in the incentive-layer repo currently don't have syntax highlighting. Github recently added support for solidity syntax highlighting, but due to name conflicts, requires each repo which wants such highlighting to add in a special .gitattributes file. This PR adds this file to the incentives-layer repo.

Contracts look very nice with highlighting turned on (for example, see https://github.com/datamined/contracts/blob/master/contracts/DataCoin.sol), so I think it will make the contracts here more readable.